### PR TITLE
fix: update datasets to v2.14.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bittensor==6.1.0
 torch==2.1.0 # we can now specify 2.1.0 so sm_90 gpus work
 transformers==4.30.0
 wandb==0.15.10
-datasets==2.14.0
+datasets==2.14.6
 plotly==5.14.1
 networkx==3.1
 scipy==1.10.1


### PR DESCRIPTION
The current version crashes with `NotImplementedError: Loading a streaming dataset cached in a LocalFileSystem is not supported yet.?`.