### PR TITLE
[autoupdate] add flag to disable autoupdate()

### DIFF
--- a/targon/miner/config.py
+++ b/targon/miner/config.py
@@ -206,6 +206,12 @@ def get_config() -> "bt.Config":
         help="If True, the miner doesnt register its wallet.",
         default=False,
     )
+    parser.add_argument(
+        "--miner.disable_auto_update",
+        action="store_true",
+        help="If true, the miner will disable auto-update of its software from the repository.",
+        default=False,
+    )
 
     # Mocks.
     parser.add_argument(

--- a/targon/miner/run.py
+++ b/targon/miner/run.py
@@ -129,7 +129,10 @@ def run(self):
                     self.config.wandb.on,
                 )
             step += 1
-            autoupdate()
+
+            # Check if we should autopdate.
+            if not self.config.miner.disable_auto_update:
+                autoupdate()
     # If someone intentionally stops the miner, it'll safely terminate operations.
     except KeyboardInterrupt:
         self.axon.stop()

--- a/targon/validator/config.py
+++ b/targon/validator/config.py
@@ -64,6 +64,12 @@ def add_args(cls, parser):
         default=DefaultRewardFrameworkConfig.correctness_weight,
     )
     parser.add_argument(
+        "--disable_auto_update",
+        action="store_true",
+        help="If true, the validator will disable auto-update of its software from the repository.",
+        default=False,
+    )
+    parser.add_argument(
         "--neuron.name",
         type=str,
         help="Trials for this miner go in miner.root / (wallet_cold - wallet_hot) / miner.name. ",

--- a/targon/validator/run.py
+++ b/targon/validator/run.py
@@ -82,8 +82,9 @@ def run(self):
                 set_weights(self)
                 save_state(self)
             
-            # Check if we should update.
-            autoupdate()
+            # Check if we should autopdate.
+            if not self.config.disable_auto_update:
+                autoupdate()
 
             # Rollover wandb to a new run.
             if should_reinit_wandb(self):


### PR DESCRIPTION
# Feature
* Adds a new flag to the `validator` and `miner`, `--disable_auto_update` for the former and `--miner.disable_auto_update` for the latter.
* Currently, the `autoupdate()` function is run without any ability to disable it.
* All other subnets (save for one) have the ability to configure this and manage updates how they see fit - this brings that functionality here.

# Testing
* I don't see any tests in this repository or a CI pipeline.
* Happy to do some testing of this feature but it isn't clear to me what is expected.
* I am `drew.unit410` on Discord if you want to chat!  I will reach out there to make you aware too.