### PR TITLE
[HOTFIX] v0.5.4b removing embedding for crawling requests

### DIFF
--- a/targon/validator/forward.py
+++ b/targon/validator/forward.py
@@ -144,12 +144,12 @@ async def forward_fn(self, validation=True, stream=False):
             self.seen_urls.update(new_unseen_links)
             self.url_queue.extend(new_unseen_links)
 
-            # Handle submissions
-            api_key = env_config.get('SYBIL_API_KEY', None)
-            if api_key is not None:
-                embedding = self.embedding_model.encode(processed_response['full_text'])
-                VectorController().submit(processed_response['uid'], processed_response['title'], processed_response['full_text'], processed_response['query'], embedding)
-                bt.logging.debug('submitted url', processed_response['uid'])
+            # # Handle submissions
+            # api_key = env_config.get('SYBIL_API_KEY', None)
+            # if api_key is not None:
+            #     embedding = self.embedding_model.encode(processed_response['full_text'])
+            #     VectorController().submit(processed_response['uid'], processed_response['title'], processed_response['full_text'], processed_response['query'], embedding)
+            #     bt.logging.debug('submitted url', processed_response['uid'])
         # validate Search Result responses
         data = select_qa(self)
 

--- a/targon/validator/neuron.py
+++ b/targon/validator/neuron.py
@@ -143,7 +143,7 @@ class neuron:
                                                             torch_dtype=torch.float16).to(self.device)
 
         # embedding model
-        self.embedding_model = AutoModel.from_pretrained('jinaai/jina-embeddings-v2-small-en', trust_remote_code=True)
+        # self.embedding_model = AutoModel.from_pretrained('jinaai/jina-embeddings-v2-small-en', trust_remote_code=True)
 
 
         self.reward_functions = [


### PR DESCRIPTION
Removing Jina model and saving the embedding to vectorstore. Validators were being prevented from setting weights due to this model