### PR TITLE
Logprob check updates

### DIFF
--- a/targon/__init__.py
+++ b/targon/__init__.py
@@ -1,7 +1,7 @@
 from .config import *
 from .dataset import *
 
-__version__ = "4.0.6"
+__version__ = "4.0.7"
 
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/targon/request.py
+++ b/targon/request.py
@@ -119,11 +119,11 @@ async def handle_inference(
                             continue
                         token_ids = choice.model_extra.get("token_ids") or []
                         token_id = token_ids[0] if len(token_ids) > 0 else -1
-                        logprobs = 0
+                        logprob = -100
                         choiceprobs = choice.logprobs
                         if choiceprobs is not None:
                             if choiceprobs.content:
-                                logprobs = choiceprobs.content[0].logprob
+                                logprob = choiceprobs.content[0].logprob
                         powv = choice.model_extra.get("powv", -1)
                         if powv is None:
                             powv = -1
@@ -132,7 +132,7 @@ async def handle_inference(
                                 "text": choice.delta.content or "",
                                 "token_id": token_id or 0,
                                 "powv": powv,
-                                "logprob": logprobs or 0,
+                                "logprob": logprob,
                             }
                         )
                 case Endpoints.COMPLETION:
@@ -154,12 +154,15 @@ async def handle_inference(
                         powv = choice.model_extra.get("powv", -1)
                         if powv is None:
                             powv = -1
+                        logprob = -100
+                        if choice.logprobs.token_logprobs:
+                            logprob = choice.logprobs.token_logprobs[0]
                         stats.tokens.append(
                             {
                                 "text": choice.text or "",
                                 "token_id": token_id or 0,
                                 "powv": powv,
-                                "logprob": choice.logprobs.token_logprobs[0] or 0,
+                                "logprob": logprob,
                             }
                         )
         except openai.APIConnectionError as e:

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -250,10 +250,9 @@ def verify_logprobs_fast(
         expected_logprob = output.prompt_logprobs[idx + len(input_tokens)]
         assert expected_logprob is not None
         expected_logprob = expected_logprob.get(item.token_id)
-        if expected_logprob is not None:
-            expected_logprob = expected_logprob.logprob
-        else:
-            expected_logprob = 0
+        if expected_logprob is None:
+            continue
+        expected_logprob = expected_logprob.logprob
         produced_logprob = item.logprob
         delta = abs(produced_logprob - expected_logprob)
         score = (1.0 - delta) ** 2

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -254,8 +254,7 @@ def verify_logprobs_fast(
             continue
         expected_logprob = expected_logprob.logprob
         produced_logprob = item.logprob
-        delta = abs(produced_logprob - expected_logprob)
-        score = (1.0 - delta) ** 2
+        score = 1.0 - min(1.0, abs(math.exp(expected_logprob) - math.exp(produced_logprob)))
 
         # To accomodate architectural difference and such, we'll give a perfect score if >= 0.9
         if score >= 0.9:


### PR DESCRIPTION
Instead of defaulting the logprob value to 0 when the token is not found in the top prompt logprobs, simply continue (which causes a score of 0 essentially for that token).  Defaulting to 0 allows some shenanigans.

Also, change the logprob score function to be more relative, with caps, so score for a single token is always in [0, 1]