### PR TITLE
fix readme for updated no-force-validator config in miner

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ less log bloat.
 Additionally:
 
 ```bash
---force-validator-permit [TRUE/FALSE]
+--no-force-validator-permit [TRUE/FALSE]
 
 ```
 
-is defaulted to true to force incoming requests to have a permit.
+is defaulted to false to force incoming requests to have a permit. Set this to true if you are having trouble getting requests from validators on the 'test' network.
 
 ## Running a Validator
 


### PR DESCRIPTION
Line Number 129 in miner.py is using an updated argument, but it's use documentation is out of date.