### PR TITLE
docs: Fixed typo in setup instructions

### DIFF
--- a/verifier/readme.md
+++ b/verifier/readme.md
@@ -1,4 +1,4 @@
-to seutp remote nodes, copy and install targon verifier on the server;
+to setup remote nodes, copy and install targon verifier on the server;
 
 1. Clone https://github.com/manifold-inc/targon
 


### PR DESCRIPTION
I corrected a typo in the setup instructions where "to seutp" was used instead of "to setup". 