### PR TITLE
fix: allow rebidding

### DIFF
--- a/targon/internal/callbacks/miners.go
+++ b/targon/internal/callbacks/miners.go
@@ -31,13 +31,13 @@ func getMinerNodes(c *targon.Core) {
 			defer c.Mnmu.Unlock()
 			if err == nil {
 				c.MinerNodes[uid] = nodes
-			} else {
-				// suppress this in prod; we can always check mongo for errors
-				c.Deps.Log.Debugw("error getting miner nodes", "uid", uid, "error", err)
-				c.MinerNodesErrors[uid] = err.Error()
+				totalNodes += len(nodes)
+				delete(c.MinerNodesErrors, uid)
 				return
 			}
-			totalNodes += len(nodes)
+			// suppress this in prod; we can always check mongo for errors
+			c.Deps.Log.Debugw("error getting miner nodes", "uid", uid, "error", err)
+			c.MinerNodesErrors[uid] = err.Error()
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
Fix how every 30 blocks the validator pings miner proxy for their bids but it only does this for miners that bid's failed the first time.